### PR TITLE
Update 0705-maltrail_rules.xml

### DIFF
--- a/0705-maltrail_rules.xml
+++ b/0705-maltrail_rules.xml
@@ -6,8 +6,6 @@
   -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
-</group>
-
 <group name="Maltrail,connection_attempt,">
     <rule id="64520" level="0">
         <decoded_as>CEF</decoded_as>


### PR DESCRIPTION
Remove not opened <group> section on line 9
wazuh-analysisd: ERROR: (1226): Error reading XML file 'etc/rules/0705-maltrail_rules.xml': XMLERR: Element not opened. (line 9).
wazuh-analysisd: CRITICAL: (1220): Error loading the rules: 'etc/rules/0705-maltrail_rules.xml'.